### PR TITLE
Fix issue when requesting 0 songs

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,13 +317,13 @@
                                 <br />
 
                                 <label for="limit"
-                                    >How many songs do you want? (0 to
+                                    >How many songs do you want? (1 to
                                     50)</label
                                 >
                                 <div class="input-group">
                                     <input
                                         type="number"
-                                        min="0"
+                                        min="1"
                                         max="50"
                                         step="1"
                                         id="limit"
@@ -331,7 +331,7 @@
                                         required
                                     />
                                     <div class="invalid-feedback">
-                                        Value must not be empty and between 0
+                                        Value must not be empty and between 1
                                         and 50
                                     </div>
                                 </div>

--- a/scripts/page.js
+++ b/scripts/page.js
@@ -203,7 +203,7 @@ const token_id = "personal-dj-token";
             danceValid = validateForm(dance, 0, 10);
             energyValid = validateForm(energy, 0, 10);
             popularValid = validateForm(popular, 0, 100);
-            limitValid = validateForm(limit, 0, 50);
+            limitValid = validateForm(limit, 1, 50);
 
             dance = document.getElementById(dance).value;
             energy = document.getElementById(energy).value;


### PR DESCRIPTION
Right now you can ask for 0 songs, but when you do, Spotify returns an error.
```
{"status":400,"message":"Something went wrong, no idea what happened. You're on your own!","trackResult":null}
```

This PR changes the minimum to 1 song to avoid this.